### PR TITLE
Add markdown support with section-based chunking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,3 +203,4 @@ The system now supports chunking and indexing multiple languages:
 - JSX/TSX (React components)
 - Go, Java, Rust (tree-sitter)
 - Svelte components
+- Markdown (section-based chunking by headers)

--- a/chunking/multi_language_chunker.py
+++ b/chunking/multi_language_chunker.py
@@ -16,7 +16,7 @@ class MultiLanguageChunker:
     # Supported extensions
     SUPPORTED_EXTENSIONS = {
         '.py',    # Python
-        '.js',    # JavaScript  
+        '.js',    # JavaScript
         '.jsx',   # JSX
         '.ts',    # TypeScript
         '.tsx',   # TSX
@@ -24,6 +24,7 @@ class MultiLanguageChunker:
         '.go',    # Go
         '.rs',    # Rust
         '.java',  # Java
+        '.md',    # Markdown
         '.c',     # C
         '.cpp',   # C++
         '.cc',    # C++
@@ -149,6 +150,9 @@ class MultiLanguageChunker:
                 'annotation_type_declaration': 'annotation',  # Java
                 'script_element': 'script',  # Svelte
                 'style_element': 'style',  # Svelte
+                'section': 'section',  # Markdown
+                'preamble': 'preamble',  # Markdown
+                'document': 'document',  # Markdown
             }
             
             chunk_type = chunk_type_map.get(tchunk.node_type, tchunk.node_type)

--- a/chunking/tree_sitter.py
+++ b/chunking/tree_sitter.py
@@ -85,6 +85,12 @@ try:
 except ImportError:
     logger.debug("tree-sitter-c-sharp not installed")
 
+try:
+    import tree_sitter_markdown as tsmarkdown
+    AVAILABLE_LANGUAGES['markdown'] = Language(tsmarkdown.language())
+except ImportError:
+    logger.debug("tree-sitter-markdown not installed")
+
 
 @dataclass
 class TreeSitterChunk:
@@ -804,6 +810,165 @@ class CSharpChunker(LanguageChunker):
         return metadata
 
 
+class MarkdownChunker(LanguageChunker):
+    """Markdown-specific chunker using tree-sitter.
+
+    Chunks markdown by sections based on headers (ATX headings).
+    Each section includes a header and all content until the next header.
+    """
+
+    def __init__(self):
+        super().__init__('markdown')
+
+    def _get_splittable_node_types(self) -> Set[str]:
+        """Markdown-specific splittable node types."""
+        return {
+            'section',  # Markdown sections
+            'atx_heading',  # Headers like # Title, ## Subtitle
+        }
+
+    def extract_metadata(self, node: Any, source: bytes) -> Dict[str, Any]:
+        """Extract Markdown-specific metadata."""
+        metadata = {'node_type': node.type}
+
+        # Extract heading text and level
+        if node.type == 'atx_heading':
+            # Get the heading level (count of # characters)
+            heading_text = self.get_node_text(node, source).strip()
+            level = 0
+            for char in heading_text:
+                if char == '#':
+                    level += 1
+                else:
+                    break
+
+            metadata['heading_level'] = level
+            metadata['name'] = heading_text.lstrip('#').strip()
+            metadata['type'] = 'heading'
+
+        elif node.type == 'section':
+            # Extract section information
+            # Find the heading within the section
+            for child in node.children:
+                if child.type == 'atx_heading':
+                    heading_text = self.get_node_text(child, source).strip()
+                    level = heading_text.count('#', 0, heading_text.index(' ') if ' ' in heading_text else len(heading_text))
+                    metadata['heading_level'] = level
+                    metadata['name'] = heading_text.lstrip('#').strip()
+                    metadata['type'] = 'section'
+                    break
+
+        return metadata
+
+    def chunk_code(self, source_code: str) -> List[TreeSitterChunk]:
+        """Chunk markdown into sections based on headers.
+
+        Args:
+            source_code: Markdown source code string
+
+        Returns:
+            List of TreeSitterChunk objects
+        """
+        source_bytes = bytes(source_code, 'utf-8')
+        tree = self.parser.parse(source_bytes)
+        chunks = []
+
+        # Find all heading nodes
+        def find_headings(node, headings=None):
+            """Recursively find all heading nodes."""
+            if headings is None:
+                headings = []
+
+            if node.type == 'atx_heading':
+                headings.append(node)
+
+            for child in node.children:
+                find_headings(child, headings)
+
+            return headings
+
+        headings = find_headings(tree.root_node)
+
+        if not headings:
+            # No headings found, treat entire document as one chunk
+            if source_code.strip():
+                chunks.append(TreeSitterChunk(
+                    content=source_code,
+                    start_line=1,
+                    end_line=len(source_code.split('\n')),
+                    node_type='document',
+                    language=self.language_name,
+                    metadata={'type': 'document', 'name': 'Document'}
+                ))
+            return chunks
+
+        # Create sections from headings
+        lines = source_code.split('\n')
+
+        for i, heading_node in enumerate(headings):
+            start_line, _ = self.get_line_numbers(heading_node)
+
+            # Determine end line - either the start of the next heading or end of document
+            if i + 1 < len(headings):
+                next_heading_line, _ = self.get_line_numbers(headings[i + 1])
+                end_line = next_heading_line - 1
+            else:
+                end_line = len(lines)
+
+            # Extract content for this section
+            section_lines = lines[start_line - 1:end_line]
+            content = '\n'.join(section_lines)
+
+            # Extract metadata
+            heading_text = self.get_node_text(heading_node, source_bytes).strip()
+            level = 0
+            for char in heading_text:
+                if char == '#':
+                    level += 1
+                else:
+                    break
+
+            heading_name = heading_text.lstrip('#').strip()
+
+            # Create chunk
+            chunk = TreeSitterChunk(
+                content=content,
+                start_line=start_line,
+                end_line=end_line,
+                node_type='section',
+                language=self.language_name,
+                metadata={
+                    'name': heading_name,
+                    'heading_level': level,
+                    'type': 'section'
+                }
+            )
+            chunks.append(chunk)
+
+        # Handle content before first heading (preamble)
+        if headings and headings[0].start_point[0] > 0:
+            first_heading_line = headings[0].start_point[0] + 1
+            preamble_lines = lines[:first_heading_line - 1]
+            preamble_content = '\n'.join(preamble_lines).strip()
+
+            if preamble_content:
+                preamble_chunk = TreeSitterChunk(
+                    content=preamble_content,
+                    start_line=1,
+                    end_line=first_heading_line - 1,
+                    node_type='preamble',
+                    language=self.language_name,
+                    metadata={
+                        'name': 'Preamble',
+                        'type': 'preamble'
+                    }
+                )
+                # Insert at beginning
+                chunks.insert(0, preamble_chunk)
+
+        return chunks
+
+
 class TreeSitterChunker:
     """Main tree-sitter chunker that delegates to language-specific implementations."""
     
@@ -818,6 +983,7 @@ class TreeSitterChunker:
         '.go': ('go', GoChunker),
         '.rs': ('rust', RustChunker),
         '.java': ('java', JavaChunker),
+        '.md': ('markdown', MarkdownChunker),
         '.c': ('c', CChunker),
         '.cpp': ('cpp', CppChunker),
         '.cc': ('cpp', CppChunker),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "tree-sitter-java>=0.23.5",
     "tree-sitter-javascript>=0.25.0",
     "tree-sitter-languages>=1.10.0",
+    "tree-sitter-markdown>=0.3.2",
     "tree-sitter-python>=0.23.6",
     "tree-sitter-rust>=0.24.0",
     "tree-sitter-svelte>=1.0.2",

--- a/tests/unit/test_tree_sitter.py
+++ b/tests/unit/test_tree_sitter.py
@@ -177,9 +177,12 @@ class TestTreeSitterChunker(TestCase):
         if 'python' in tsf.AVAILABLE_LANGUAGES:
             assert self.chunker.is_supported('test.py')
         
+        # Check if Markdown is supported (requires tree-sitter-markdown)
+        if 'markdown' in tsf.AVAILABLE_LANGUAGES:
+            assert self.chunker.is_supported('test.md')
+
         # These won't be supported without their packages
         assert not self.chunker.is_supported('test.txt')
-        assert not self.chunker.is_supported('test.md')
     
     def test_chunk_python_file(self):
         """Test chunking a Python file."""

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,7 @@ dependencies = [
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-languages" },
+    { name = "tree-sitter-markdown" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-svelte" },
@@ -183,6 +184,7 @@ requires-dist = [
     { name = "tree-sitter-java", specifier = ">=0.23.5" },
     { name = "tree-sitter-javascript", specifier = ">=0.25.0" },
     { name = "tree-sitter-languages", specifier = ">=1.10.0" },
+    { name = "tree-sitter-markdown", specifier = ">=0.3.2" },
     { name = "tree-sitter-python", specifier = ">=0.23.6" },
     { name = "tree-sitter-rust", specifier = ">=0.24.0" },
     { name = "tree-sitter-svelte", specifier = ">=1.0.2" },
@@ -1932,6 +1934,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/76/25bb32a9be1c476e388835d5c8de5af2920af055e295770003683896cfe2/tree_sitter_languages-1.10.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1aeabd3d60d6d276b73cd8f3739d595b1299d123cc079a317f1a5b3c5461e2ca", size = 8956249, upload-time = "2024-02-04T10:28:57.094Z" },
     { url = "https://files.pythonhosted.org/packages/52/01/8e2f97a444d25dde1380ec20b338722f733b6cc290524357b1be3dd452ab/tree_sitter_languages-1.10.2-cp312-cp312-win32.whl", hash = "sha256:fab8ee641914098e8933b87ea3d657bea4dd00723c1ee7038b847b12eeeef4f5", size = 8363094, upload-time = "2024-02-04T10:28:59.156Z" },
     { url = "https://files.pythonhosted.org/packages/47/58/0262e875dd899447476a8ffde7829df3716ffa772990095c65d6de1f053c/tree_sitter_languages-1.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:5e606430d736367e5787fa5a7a0c5a1ec9b85eded0b3596bbc0d83532a40810b", size = 8268983, upload-time = "2024-02-04T10:29:00.987Z" },
+]
+
+[[package]]
+name = "tree-sitter-markdown"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/87/8f705d8f99337c8a691bcc8c22d89ddd323eb2b860a78ae2e894b9f7ade1/tree_sitter_markdown-0.5.1.tar.gz", hash = "sha256:6c69d7270a7e09be8988ced44584c09a6a4f541cea0dc394dd1c1a5ac3b5601d", size = 250138, upload-time = "2025-09-16T17:12:11.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/73/b5f88217a526f61080ddd71d554cff6a01ea23fffa584ad9de41ee8d1fe5/tree_sitter_markdown-0.5.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:f00ce3f48f127377983859fcb93caf0693cbc7970f8c41f1e2bd21e4d56bdfd8", size = 139706, upload-time = "2025-09-16T17:12:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/9b/65eb5e6a8d7791174644854437d35849d9b4e4ed034d54d2c78810eaf1a6/tree_sitter_markdown-0.5.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1ec4cc5d7b0d188bad22247501ab13663bb1bf1a60c2c020a22877fabce8daa9", size = 147540, upload-time = "2025-09-16T17:12:04.955Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d5/4152d00829c8643243f65b67a5485248661824f15e1868e14e54f03c2069/tree_sitter_markdown-0.5.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727242a70c46222092eba86c102301646f21ba32aee221f4b1f70e2020755e81", size = 187851, upload-time = "2025-09-16T17:12:05.813Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/c1/994001c5a51d09e9da7236e01a855d3d49437a47fa8669f1d5e9ed60e64f/tree_sitter_markdown-0.5.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0b2fde19e692bb90e300d9788887528c624b659c794de6337f8193396de4399", size = 187563, upload-time = "2025-09-16T17:12:06.929Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d1/1f2ba1ae11568639f133c45c7a697e4e9277d6cc26a66c0caee62c11d1c2/tree_sitter_markdown-0.5.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:13da82db04cec7910b6afd4a67d02da9ef402df8d56fc6ed85e00584af1730ee", size = 185478, upload-time = "2025-09-16T17:12:08.126Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c8/8218482d56b78755cdc20816a28754145cb1767e1e7e0ddde5988547ab86/tree_sitter_markdown-0.5.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b8a8a04a5d942c177cc590ec40074fcf3658f3a7c0a3388a8575990003665d8c", size = 184922, upload-time = "2025-09-16T17:12:08.937Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ca/423600960b91c3aba6f2202ad4c430b5401e652d51a73a59769375c2b4ea/tree_sitter_markdown-0.5.1-cp39-abi3-win_amd64.whl", hash = "sha256:b1b0e4cbcf5a7b85005f1e9266fc2ed9b649b41a6048f3b1abae3612368d97a6", size = 142519, upload-time = "2025-09-16T17:12:10.027Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f5/327dd7fa42ae39796a8853685c40a8ac968585260094c581047270cbc851/tree_sitter_markdown-0.5.1-cp39-abi3-win_arm64.whl", hash = "sha256:2296ef53a757d8f5b848616706d0518e04d487bc7748bd05755d4a3a65711542", size = 137166, upload-time = "2025-09-16T17:12:10.858Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds tree-sitter-based markdown chunking that intelligently splits documents by ATX headers (# sections).

##  Changes

  - New: MarkdownChunker class in chunking/tree_sitter.py (+166 lines)
  - Added: tree-sitter-markdown>=0.3.2 dependency
  - Enhanced: .md file support in MultiLanguageChunker
  - Updated: Test suite and documentation

##  How It Works

  Chunks markdown by ATX headings (#, ##, ###, etc.):
  - Each section = heading + content until next heading
  - Extracts heading level and name as metadata
  - Handles preamble content before first heading
  - Treats documents without headings as single chunk

##  Example
```md
  # Introduction         → Section chunk (level 1, "Introduction")
  Content here...

  ## Features           → Section chunk (level 2, "Features")
  More content...

  ### Details           → Section chunk (level 3, "Details")
  ...
```

##  Metadata per Chunk
```js
  {
      'name': 'Introduction',       # Heading text
      'heading_level': 1,           # Number of # characters
      'type': 'section',            # or 'preamble', 'document'
      'node_type': 'section'        # tree-sitter node type
  }
```