### PR TITLE
Fix MCP server log level to avoid stdio noise

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -7,14 +7,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import logging
 
-# Configure logging
+# Configure logging — WARNING level for stdio to avoid noisy stderr
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.WARNING,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
-logging.getLogger("mcp").setLevel(logging.DEBUG)
-logging.getLogger("fastmcp").setLevel(logging.DEBUG)
+logging.getLogger("mcp").setLevel(logging.WARNING)
+logging.getLogger("fastmcp").setLevel(logging.WARNING)
 
 from mcp_server.code_search_server import CodeSearchServer
 from mcp_server.code_search_mcp import CodeSearchMCP


### PR DESCRIPTION
## Summary

- Change `logging.basicConfig` level from `DEBUG` to `WARNING` in `mcp_server/server.py`
- Set `mcp` and `fastmcp` loggers to `WARNING` instead of `DEBUG`

## Problem

When running as an stdio MCP server, `DEBUG`-level logging from the `mcp` and `fastmcp` libraries floods stderr. Since Claude Code reads stderr as part of the MCP communication channel, this noise can:

- Corrupt the JSON-RPC stream
- Cause protocol errors or connection failures
- Make the MCP server appear broken or unresponsive

## Fix

Switching to `WARNING` silences internal debug chatter, keeping only meaningful output on the stream — which is required for correct MCP stdio operation.

## Test plan

- [ ] Start the MCP server and verify no debug spam appears in stderr
- [ ] Confirm MCP tools (`search_code`, `index_directory`, etc.) work correctly in Claude Code
- [ ] Verify that actual warnings/errors still surface when they occur